### PR TITLE
Updated glue.js to be ready to used as a module in browser env

### DIFF
--- a/src/glue.js
+++ b/src/glue.js
@@ -1,4 +1,4 @@
-import { coerceArray } from "./utils";
+import { coerceArray } from "./utils.js";
 
 function createEnv() {
   const memory = new WebAssembly.Memory({ initial: 256, maximum: 256 });


### PR DESCRIPTION
This is needed if someone wants to use this in own project as a git submodule without babel (most browsers supports es6 modules natively)